### PR TITLE
use config for cosign info

### DIFF
--- a/images.yaml.example
+++ b/images.yaml.example
@@ -1,0 +1,16 @@
+destination:
+  registry: 192.168.106.2:5000
+  secure: true
+cosign_verifiers:
+  - registry: registry1.dso.mil
+    repo: ironbank/*
+    key: /app/ib-cosign.pub
+  - registry: registry.example.com
+    repo: foo/bar/baz
+    key: /app/example-cosign.pub
+exclude:
+  - docker.io/library/alpine:3
+images: []
+  - docker.io/library/busybox:latest
+include:
+  - docker.io/library/nginx: 1.23.3

--- a/imagesync.py
+++ b/imagesync.py
@@ -32,13 +32,6 @@ def main():
         default=pathlib.Path(os.path.dirname(__file__)).joinpath("images.yaml"),
     )
 
-    parser.add_argument(
-        "-k",
-        "--cosign-public-key",
-        help="Path to cosign public key",
-        default=pathlib.Path(os.path.dirname(__file__)).joinpath("cosign.pub"),
-    )
-
     subparser = parser.add_subparsers(help="", dest="command")
 
     tidy_subparser = subparser.add_parser("tidy")
@@ -132,7 +125,7 @@ def main():
         if args.insecure:
             config.destination["secure"] = False
         # Instantiate Transfer
-        transferer = transfer.Transfer(config, pubkey=args.cosign_public_key)
+        transferer = transfer.Transfer(config)
         # Execute Transfer
         try:
             transferer.execute()

--- a/modules/transfer.py
+++ b/modules/transfer.py
@@ -14,7 +14,7 @@ class Transfer:
     def __init__(self, config: Config):
         self.registry: str = config.destination["registry"]
         self.secure: bool = config.destination["secure"]
-        self.images: [Image] = config.images
+        self.images: list[Image] = config.images
         self.cosign_verifiers = config.cosign_verifiers
 
     def _cosign_verify(self, image: Image, pubkey: Path):
@@ -28,12 +28,11 @@ class Transfer:
         total_images = len(self.images)
         for count, source in enumerate(self.images):
             proceed = True
-            cosign_verifier = None
             for verifier in self.cosign_verifiers:
-                if source.registry() == verifier["registry"] and re.match(
+                if source.registry() == verifier.registry and re.match(
                     verifier.repo, source.repo()
                 ):
-                    proceed = self._cosign_verify(source, pubkey=cosign_verifier["key"])
+                    proceed = self._cosign_verify(source, pubkey=verifier.key)
 
             if proceed:
                 destination = Image.new_registry(source, self.registry, self.secure)

--- a/modules/transfer.py
+++ b/modules/transfer.py
@@ -39,7 +39,7 @@ class Transfer:
                 False,
             )
             if cosign_registry:
-                proceed = self._cosign_verify(source, cosign_registry["key"])
+                proceed = self._cosign_verify(source, pubkey=cosign_registry["key"])
 
             if proceed:
                 destination = Image.new_registry(source, self.registry, self.secure)

--- a/modules/transfer.py
+++ b/modules/transfer.py
@@ -33,13 +33,16 @@ class Transfer:
                 (
                     item
                     for item in self.cosign_registries
-                    if item["registry"] == source.registry()
-                    and item["repo"] == source.repo().split("/")[0]
+                    if item.get("registry") == source.registry()
+                    and (
+                        item.get("repo") is None
+                        or item.get("repo") == source.repo().split("/")[0]
+                    )
                 ),
                 False,
             )
             if cosign_registry:
-                proceed = self._cosign_verify(source, pubkey=cosign_registry["key"])
+                proceed = self._cosign_verify(source, pubkey=cosign_registry.get("key"))
 
             if proceed:
                 destination = Image.new_registry(source, self.registry, self.secure)

--- a/modules/transfer.py
+++ b/modules/transfer.py
@@ -30,7 +30,9 @@ class Transfer:
             proceed = True
             cosign_verifier = None
             for verifier in self.cosign_verifiers:
-                if source.registry() == verifier["registry"] and re.match(verifier.repo, source.repo()):
+                if source.registry() == verifier["registry"] and re.match(
+                    verifier.repo, source.repo()
+                ):
                     proceed = self._cosign_verify(source, pubkey=cosign_verifier["key"])
 
             if proceed:

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -15,7 +15,9 @@ class Config(yaml.YAMLObject):
         # Convert exclude in config to Image type
         self.exclude = [Image(image["name"]) for image in exclude]
 
-        self.cosign_verifiers: [CosignVerifier(verifier) for verifier in cosign_verifiers]
+        self.cosign_verifiers: [
+            CosignVerifier(verifier) for verifier in cosign_verifiers
+        ]
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -28,11 +30,13 @@ class Config(yaml.YAMLObject):
     def find_unused_images(self, used_images: [Image]) -> [Image]:
         return [image for image in self.images if image not in used_images]
 
+
 @dataclass(frozen=True)
 class CosignVerifier:
     registry: str
     repo: str
     key: str
+
 
 # Override emitter to avoid outputting untrusted python object tags into generated yaml
 yaml.emitter.Emitter.process_tag = lambda self, *args, **kwargs: None

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -1,5 +1,6 @@
 import yaml
 
+from pathlib import Path
 from dataclasses import dataclass, field
 from .image import Image
 
@@ -15,8 +16,13 @@ class Config(yaml.YAMLObject):
         # Convert exclude in config to Image type
         self.exclude = [Image(image["name"]) for image in exclude]
 
-        self.cosign_verifiers: [
-            CosignVerifier(verifier) for verifier in cosign_verifiers
+        self.cosign_verifiers = [
+            CosignVerifier(
+                registry=verifier["registry"],
+                repo=verifier["repo"],
+                key=Path(verifier["key"]),
+            )
+            for verifier in cosign_verifiers
         ]
 
         for k, v in kwargs.items():
@@ -27,7 +33,7 @@ class Config(yaml.YAMLObject):
             list({Image(image.name) for image in self.images}), key=lambda x: x.name
         )
 
-    def find_unused_images(self, used_images: [Image]) -> [Image]:
+    def find_unused_images(self, used_images: list[Image]) -> list[Image]:
         return [image for image in self.images if image not in used_images]
 
 
@@ -35,7 +41,7 @@ class Config(yaml.YAMLObject):
 class CosignVerifier:
     registry: str
     repo: str
-    key: str
+    key: Path
 
 
 # Override emitter to avoid outputting untrusted python object tags into generated yaml

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -42,8 +42,10 @@ class CosignVerifier:
     registry: str
     repo: str
     key: str
+
     def __post_init__(self):
         object.__setattr__(self, "key", Path(self.key))
+
 
 # Override emitter to avoid outputting untrusted python object tags into generated yaml
 yaml.emitter.Emitter.process_tag = lambda self, *args, **kwargs: None

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -20,7 +20,7 @@ class Config(yaml.YAMLObject):
             CosignVerifier(
                 registry=verifier["registry"],
                 repo=verifier["repo"],
-                key=Path(verifier["key"]),
+                key=verifier["key"],
             )
             for verifier in cosign_verifiers
         ]
@@ -41,8 +41,9 @@ class Config(yaml.YAMLObject):
 class CosignVerifier:
     registry: str
     repo: str
-    key: Path
-
+    key: str
+    def __post_init__(self):
+        object.__setattr__(self, "key", Path(self.key))
 
 # Override emitter to avoid outputting untrusted python object tags into generated yaml
 yaml.emitter.Emitter.process_tag = lambda self, *args, **kwargs: None

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -5,7 +5,7 @@ from .image import Image
 
 
 class Config(yaml.YAMLObject):
-    def __init__(self, images, include, exclude, **kwargs):
+    def __init__(self, images, include, exclude, cosign_verifiers, **kwargs):
         # Convert images in config to Image type
         self.images = [Image(image["name"]) for image in images]
 
@@ -14,6 +14,8 @@ class Config(yaml.YAMLObject):
 
         # Convert exclude in config to Image type
         self.exclude = [Image(image["name"]) for image in exclude]
+
+        self.cosign_verifiers: [CosignVerifier(verifier) for verifier in cosign_verifiers]
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -26,6 +28,11 @@ class Config(yaml.YAMLObject):
     def find_unused_images(self, used_images: [Image]) -> [Image]:
         return [image for image in self.images if image not in used_images]
 
+@dataclass(frozen=True)
+class CosignVerifier:
+    registry: str
+    repo: str
+    key: str
 
 # Override emitter to avoid outputting untrusted python object tags into generated yaml
 yaml.emitter.Emitter.process_tag = lambda self, *args, **kwargs: None


### PR DESCRIPTION
So how's this for an idea @chaospuppy?  Instead of passing the cosign key path via an arg, what about adding a cosign block to the `images.yaml` like below.  You'd still need to make sure that you mounted in the keys, but this could handle our "optional" problem along with allowing for multiple registries/keys.  Thoughts?

```
cosign:
  - registry: registry1.dso.mil
    repo: ironbank
    key: /app/ib-cosign.pub
  - registry: docker.io
    repo: chaospuppy
    key: /app/cp-cosign.pub
```

TODO:
* should `repo:` be able to include more of the image path where relevant? i.e. for cases like `{registry}/{repo}/anchore` if for some reason that was signed with a different key?